### PR TITLE
windows compatibility

### DIFF
--- a/load_compressed_nii.m
+++ b/load_compressed_nii.m
@@ -13,12 +13,12 @@ function [nifti_out] = load_compressed_nii(image_path)
     % assign a new tmp_id to each volume is useful when the same images are used in parallel
     [folder, f] = fileparts(image_path);
     tmp_id = num2str(round(rand*1000*s(6)));
-    tmppath = fullfile('/','tmp',[f,'_', tmp_id,'.nii.gz']);
+    tmppath = fullfile(tempdir,[f,'_', tmp_id,'.nii.gz']);
     copyfile([image_path,'.nii.gz'], tmppath);
     gunzip(tmppath);
-    nifti_out = load_untouch_nii(fullfile('/','tmp',[f,'_', tmp_id,'.nii']));
-    delete(fullfile('/','tmp',[f,'_', tmp_id,'.nii.gz']));
-    if exist(tmppath, 'file')
+    nifti_out = load_nii(tmppath);
+    delete(tmppath);
+    if exist(tmppath, 'file') % ??
         delete(tmppath);
     end
 end

--- a/load_compressed_nii.m
+++ b/load_compressed_nii.m
@@ -1,5 +1,5 @@
 
-function [nifti_out] = load_compressed_nii(image_path)
+function [nifti_out] = load_compressed_nii(image_path, untouch)
 %*****************************************************************
 % LOAD NIFTI compressed nifti
 %    
@@ -8,18 +8,52 @@ function [nifti_out] = load_compressed_nii(image_path)
 % This library makes use of the wonderful toolbox provided by Jimmy Shen. 
 % https://www.mathworks.com/matlabcentral/fileexchange/8797-tools-for-nifti-and-analyze-image    
 % 
+% USE: 
+%   [nifti_out] = load_compressed_nii(image_path, untouch)
+% IN:
+%   image_path - full path to compressed nifti file (*.nii.gz)
+%   untouch    - if true, uses load_untouch_nii instead of load_nii (default:0)
+% OUT:
+%   nifti_out  - loaded nifti structure from niftiTools
+%
 % ****************************************************************  
-    s = clock;
-    % assign a new tmp_id to each volume is useful when the same images are used in parallel
-    [folder, f] = fileparts(image_path);
+
+    if(nargin<2)
+        untouch = 0;
+    end
+    
+    % input file: full path with extension only
+    if(~exist(image_path,'file'))
+        error('Input file not found: %s',image_path);
+    end
+    [~, fnm] = fileparts(image_path);    
+    [~,fnm] = fileparts(fnm); % get rid of *.nii
+    
+    % assign a new tmp_id to each volume is useful when the same images are used in parallel    
+    s = clock;    
     tmp_id = num2str(round(rand*1000*s(6)));
-    tmppath = fullfile(tempdir,[f,'_', tmp_id,'.nii.gz']);
-    copyfile([image_path,'.nii.gz'], tmppath);
-    gunzip(tmppath);
-    nifti_out = load_nii(tmppath);
-    delete(tmppath);
-    if exist(tmppath, 'file') % ??
-        delete(tmppath);
+    tmppath = fullfile(tempdir(),[fnm,'_', tmp_id]);
+    tmpGZ = [tmppath '.nii.gz'];   
+    tmpNII = [tmppath '.nii'];
+    
+    % copy original *.nii.gz to temp folder + unzip
+    copyfile(image_path, tmpGZ);    
+    filenames = gunzip(tmpGZ);
+    if(length(filenames)~=1)
+        warning('multiple (%s) files in the gzip archive: probably not a proper .nii.gz file')
+    end
+    
+    % load unzipped
+    if(untouch)
+        nifti_out = load_untouch_nii(tmpNII);
+    else
+        nifti_out = load_nii(tmpNII);
+    end
+    
+    % clean-up both
+    delete(tmpGZ);
+    if exist(tmpNII, 'file')
+        delete(tmpNII);
     end
 end
 

--- a/save_compressed_nii.m
+++ b/save_compressed_nii.m
@@ -21,7 +21,10 @@ function save_compressed_nii(nii_struct, output_path, untouch)
         untouch = false;
     end
     
-    tmpNII = [output_path,'_tmp_.nii'];
+    [pth, fname] = fileparts(output_path);
+    [~,fname] = fileparts(fname);
+    
+    tmpNII = [pth '/',fname,'_tmp_.nii'];
     tmpGZ = [tmpNII '.gz'];
     
     % create temporary nii file

--- a/save_compressed_nii.m
+++ b/save_compressed_nii.m
@@ -1,4 +1,4 @@
-function save_compressed_nii(nii_image, image_path)
+function save_compressed_nii(nii_struct, output_path, untouch)
 %*****************************************************************
 % SAVE NIFTI compressed nifti
 %    
@@ -7,11 +7,33 @@ function save_compressed_nii(nii_image, image_path)
 % This library makes use of the wonderful toolbox provided by Jimmy Shen. 
 % https://www.mathworks.com/matlabcentral/fileexchange/8797-tools-for-nifti-and-analyze-image    
 % 
+% USE:
+%   save_compressed_nii(nii_image, image_path)
+% IN:
+%   nii_struct  - niftiTools structure, containing nifti data
+%   output_path - full filename to write the output nifti image, including
+%                 file extension
+%   untouch     - if true, use save_untouch_nii instead of save_nii (default:0)
+%   
 % ****************************************************************  
     
-    save_untouch_nii(nii_image, [image_path,'_tmp_.nii']); 
-    gzip([image_path,'_tmp_.nii']);
-    movefile([image_path,'_tmp_.nii.gz'], [image_path,'.nii.gz']);
-    delete([image_path,'_tmp_.nii']);
+    if(nargin<3)
+        untouch = false;
+    end
+    
+    tmpNII = [output_path,'_tmp_.nii'];
+    tmpGZ = [tmpNII '.gz'];
+    
+    % create temporary nii file
+    if(untouch)
+        save_untouch_nii(nii_struct, tmpNII); 
+    else
+        save_nii(nii_struct,tmpNII);
+    end
+    
+    % gzip + clear temporary *.nii file
+    gzip(tmpNII);
+    movefile(tmpGZ, output_path);
+    delete(tmpNII);
    
 end


### PR DESCRIPTION
Hi, I came across your great extension to niftiTools, however, it did not work on Win (different name of the temp folder). I also added the ability to use both load_untouch_nii or load_nii (default) and added several checks - it might come handy, so just letting you know..

Tested using Matlab on win (2011b  for bw comp.) and Linux (2017a)